### PR TITLE
Fix string when using less than 15 scale

### DIFF
--- a/BetterItemScan - Code behind the scenes/Patches/HudManagerPatch_UI.cs
+++ b/BetterItemScan - Code behind the scenes/Patches/HudManagerPatch_UI.cs
@@ -203,10 +203,10 @@ namespace BetterItemScan.Patches
                 }
                 else
                 {
-                    HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}/nShip Total: {Totalship.ToString()}";
+                    HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}\nShip Total: {Totalship.ToString()}";
                 }
             }
-            else HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}/nShip Total: {Totalship.ToString()}";
+            else HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}\nShip Total: {Totalship.ToString()}";
                         
             if (BetterItemScanModBase.ShowTotalOnShipOnly.Value)
             {

--- a/BetterItemScan - Code behind the scenes/Patches/HudManagerPatch_UI.cs
+++ b/BetterItemScan - Code behind the scenes/Patches/HudManagerPatch_UI.cs
@@ -203,10 +203,10 @@ namespace BetterItemScan.Patches
                 }
                 else
                 {
-                    HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()} Ship Total: {Totalship.ToString()}";
+                    HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}/nShip Total: {Totalship.ToString()}";
                 }
             }
-            else HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()} Ship Total: {Totalship.ToString()}";
+            else HudManagerPatch_UI._textMesh.text += $"\nTotal Scanned: {Totalsum.ToString()}/nShip Total: {Totalship.ToString()}";
                         
             if (BetterItemScanModBase.ShowTotalOnShipOnly.Value)
             {


### PR DESCRIPTION
When lowering scale, the `Ship Total` message gets into the same line as `Total Scanned` and sometimes gets cut out of the screen, using an `\n` instead of space should fix the issue